### PR TITLE
Allow higher versions of JQuery

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,6 @@
     "index.html"
   ],
   "dependencies": {
-    "jquery": "1.6.0"
+    "jquery": ">=1.6.0"
   }
 }


### PR DESCRIPTION
Additionally, bower has the following notification when installing your package:

- bower jquery-geolocation#*     invalid-meta jQuery-Geolocation is missing "main" entry in bower.json